### PR TITLE
Update to stable api

### DIFF
--- a/charts/solr/templates/poddisruptionbudget.yaml
+++ b/charts/solr/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 ---
-apiVersion: "policy/v1beta1"
+{{- if semverCompare "<1.21.0-0" ( .Capabilities.KubeVersion.GitVersion ) }}
+apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
+{{- end }}
 kind: "PodDisruptionBudget"
 metadata:
   name: "{{ include "solr.fullname" . }}"

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,11 +1,18 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "nbgallery.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- $fullName := include "nbgallery.fullname" . -}}
+  {{- $svcPort := .Values.service.port -}}
+  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+  {{- end }}
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+  {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+  {{- else -}}
 apiVersion: extensions/v1beta1
-{{- end }}
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,26 +23,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-        {{- end }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
   {{- end }}
-{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,18 +1,18 @@
 {{- if .Values.ingress.enabled -}}
-  {{- $fullName := include "nbgallery.fullname" . -}}
-  {{- $svcPort := .Values.service.port -}}
-  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- $fullName := include "nbgallery.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
-  {{- end }}
-  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-  {{- else -}}
+{{- else -}}
 apiVersion: extensions/v1beta1
-  {{- end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -58,4 +58,4 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -112,9 +112,10 @@ ingress:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "false"
   hosts:
-    # - host: nbgallery.example.com
-    #   paths:
-    #     - "/"
+  # - host: nbgallery.example.com
+  #   paths:
+  #   - path: "/"
+  #     pathType: ImplementationSpecific
   tls:
     # - secretName: nbgallery-tls
     #   hosts:


### PR DESCRIPTION
I've updated the chart (Ingress and PDB) to use newer API versions if the Kubernetes version supports them. `values.yaml` was also updated so that the example value has pathType, which is needed for the stable version of Ingress.