### PR TITLE
removed problematic annotations

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -108,9 +108,6 @@ service:
     # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 ingress:
   enabled: false
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "false"
   hosts:
   # - host: nbgallery.example.com
   #   paths:


### PR DESCRIPTION
The values file contained the kubernetes.io/ingress.class annotation, which is [deprecated](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation). Setting this annotation and also using the newer method is not allowed by Kubernetes.

What makes this a problem is a bug in Helm that prevents unsetting a value in a subchart. There's a fix in the works, but [it isn't released yet](https://github.com/helm/helm/pull/11440#issuecomment-1669753459). As is, it's impossible to set the ingressClass the new way because it conflicts with the annotation.

The kubernetes.io/tls-acme annotation is false by default, so there's no need to set it.